### PR TITLE
Bugfix in copy() method

### DIFF
--- a/src/main/java/com/alexkasko/unsafe/offheap/DirectOffHeapMemory.java
+++ b/src/main/java/com/alexkasko/unsafe/offheap/DirectOffHeapMemory.java
@@ -252,7 +252,7 @@ class DirectOffHeapMemory extends OffHeapMemory {
     @Override
     public void copy(long offset, OffHeapMemory destination, long destOffset, long bytes) {
         DirectOffHeapMemory dest = (DirectOffHeapMemory) destination;
-        bb.clear().position((int) offset);
+        bb.clear().position((int) offset).limit((int) (offset + bytes));
         dest.bb.clear().position((int) destOffset);
         dest.bb.put(bb);
     }


### PR DESCRIPTION
Fixed bug in buffer set up (buffer limit was not set, bytes parameter was not
used at all) when input buffer is not to be used completely (i.e. offset != 0)
